### PR TITLE
MAINT-25835: Reset default permissions for all old wikis and their related pages

### DIFF
--- a/data-upgrade-wiki-editor/upgrade/pom.xml
+++ b/data-upgrade-wiki-editor/upgrade/pom.xml
@@ -134,6 +134,21 @@
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
+	<dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/data-upgrade-wiki-editor/upgrade/src/main/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePlugin.java
+++ b/data-upgrade-wiki-editor/upgrade/src/main/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePlugin.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2003-2020 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.wiki.migration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.wiki.WikiException;
+import org.exoplatform.wiki.jpa.JPADataStorage;
+import org.exoplatform.wiki.mow.api.Page;
+import org.exoplatform.wiki.mow.api.PermissionEntry;
+import org.exoplatform.wiki.mow.api.Wiki;
+import org.exoplatform.wiki.mow.api.WikiType;
+import org.exoplatform.wiki.service.WikiService;
+
+/**
+ * Created by The eXo Platform SAS Author : Ayoub Zayati Sept 14, 2020 
+ * This plugin will be executed in order to reset default permissions for all wikis and their related pages
+ */
+public class WikiPermissionsUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log log = ExoLogger.getLogger(WikiPermissionsUpgradePlugin.class.getName());
+
+  private WikiService      wikiService;
+
+  private int              wikiPermissionsUpdatedCount;
+  
+  private int              wikiPagesPermissionsUpdatedCount;
+  
+  private JPADataStorage jpaDataStorage;
+
+  public WikiPermissionsUpgradePlugin(InitParams initParams,
+                                      WikiService wikiService,
+                                      JPADataStorage jpaDataStorage) {
+    super(initParams);
+    this.wikiService = wikiService;
+    this.jpaDataStorage = jpaDataStorage;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    log.info("Start upgrade of wiki permissions");
+    try {
+      
+      List<Wiki> allWikiList = wikiService.getAllWikis();
+      for (Wiki wiki : allWikiList) {
+        setWikiPermissions(wiki);
+        setWikiPagesPermissions(wiki);
+      }
+      log.info("End upgrade of '{}' wiki permissions and '{}' wiki pages permissions. It took {} ms",
+               wikiPermissionsUpdatedCount, wikiPagesPermissionsUpdatedCount,
+               (System.currentTimeMillis() - startupTime));
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("An unexpected error occurs when migrating wiki and pages permissions:", e);
+      }
+    }
+  }
+
+  /**
+   * @return the wikiPermissionsUpdatedCount
+   */
+  public int getWikiPermissionsUpdatedCount() {
+    return wikiPermissionsUpdatedCount;
+  }
+  
+  /**
+   * @return the wikiPagesPermissionsUpdatedCount
+   */
+  public int getWikiPagesPermissionsUpdatedCount() {
+    return wikiPagesPermissionsUpdatedCount;
+  }
+
+  public void setWikiPermissions(Wiki wiki) throws WikiException {
+    List<PermissionEntry> defaultPermissions = wikiService.getWikiDefaultPermissions(wiki.getType(), wiki.getOwner());
+    wiki.setPermissions(defaultPermissions);
+    wikiPermissionsUpdatedCount ++;
+  }
+  
+  public void setWikiPagesPermissions(Wiki wiki) throws WikiException {
+    List<Page> wikiPagesList = wikiService.getPagesOfWiki(wiki.getType(), wiki.getOwner());
+    List<PermissionEntry> defaultPermissions = jpaDataStorage.getWikiHomePageDefaultPermissions(wiki.getType(), wiki.getOwner());
+    for (Page wikiPage : wikiPagesList) {
+      wikiPage.setPermissions(defaultPermissions);
+      wikiPagesPermissionsUpdatedCount ++;
+    }
+  }
+}

--- a/data-upgrade-wiki-editor/upgrade/src/main/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePlugin.java
+++ b/data-upgrade-wiki-editor/upgrade/src/main/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePlugin.java
@@ -16,10 +16,7 @@
  */
 package org.exoplatform.wiki.migration;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.container.xml.InitParams;
@@ -30,11 +27,10 @@ import org.exoplatform.wiki.jpa.JPADataStorage;
 import org.exoplatform.wiki.mow.api.Page;
 import org.exoplatform.wiki.mow.api.PermissionEntry;
 import org.exoplatform.wiki.mow.api.Wiki;
-import org.exoplatform.wiki.mow.api.WikiType;
 import org.exoplatform.wiki.service.WikiService;
 
 /**
- * Created by The eXo Platform SAS Author : Ayoub Zayati Sept 14, 2020 
+ * Created by The eXo Platform SAS Author : Ayoub Zayati Oct 12, 2020 
  * This plugin will be executed in order to reset default permissions for all wikis and their related pages
  */
 public class WikiPermissionsUpgradePlugin extends UpgradeProductPlugin {

--- a/data-upgrade-wiki-editor/upgrade/src/main/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePlugin.java
+++ b/data-upgrade-wiki-editor/upgrade/src/main/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePlugin.java
@@ -27,6 +27,7 @@ import org.exoplatform.wiki.jpa.JPADataStorage;
 import org.exoplatform.wiki.mow.api.Page;
 import org.exoplatform.wiki.mow.api.PermissionEntry;
 import org.exoplatform.wiki.mow.api.Wiki;
+import org.exoplatform.wiki.service.PageUpdateType;
 import org.exoplatform.wiki.service.WikiService;
 
 /**
@@ -88,17 +89,18 @@ public class WikiPermissionsUpgradePlugin extends UpgradeProductPlugin {
     return wikiPagesPermissionsUpdatedCount;
   }
 
-  public void setWikiPermissions(Wiki wiki) throws WikiException {
+  private void setWikiPermissions(Wiki wiki) throws WikiException {
     List<PermissionEntry> defaultPermissions = wikiService.getWikiDefaultPermissions(wiki.getType(), wiki.getOwner());
-    wiki.setPermissions(defaultPermissions);
+    wikiService.updateWikiPermission(wiki.getType(), wiki.getOwner(), defaultPermissions);
     wikiPermissionsUpdatedCount ++;
   }
   
-  public void setWikiPagesPermissions(Wiki wiki) throws WikiException {
+  private void setWikiPagesPermissions(Wiki wiki) throws WikiException {
     List<Page> wikiPagesList = wikiService.getPagesOfWiki(wiki.getType(), wiki.getOwner());
     List<PermissionEntry> defaultPermissions = jpaDataStorage.getWikiHomePageDefaultPermissions(wiki.getType(), wiki.getOwner());
     for (Page wikiPage : wikiPagesList) {
       wikiPage.setPermissions(defaultPermissions);
+      wikiService.updatePage(wikiPage, PageUpdateType.EDIT_PAGE_PERMISSIONS);
       wikiPagesPermissionsUpdatedCount ++;
     }
   }

--- a/data-upgrade-wiki-editor/upgrade/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-wiki-editor/upgrade/src/main/resources/conf/portal/configuration.xml
@@ -39,7 +39,7 @@
       <name>WikiPermissionsUpgradePlugin</name>
       <set-method>addUpgradePlugin</set-method>
       <type>org.exoplatform.wiki.migration.WikiPermissionsUpgradePlugin</type>
-      <description>Update wiki and pages with default permissions</description>
+      <description>Reset default permissions for all wikis and their related pages</description>
       <init-params>
         <value-param>
           <name>product.group.id</name>

--- a/data-upgrade-wiki-editor/upgrade/src/main/resources/conf/portal/configuration.xml
+++ b/data-upgrade-wiki-editor/upgrade/src/main/resources/conf/portal/configuration.xml
@@ -32,5 +32,42 @@
   <component profiles="wiki">
     <type>org.exoplatform.wiki.migration.WikiPageContentMigrationUpgradePlugin</type>
   </component>
+  
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin profiles="wiki">
+      <name>WikiPermissionsUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>org.exoplatform.wiki.migration.WikiPermissionsUpgradePlugin</type>
+      <description>Update wiki and pages with default permissions</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>6.1.0</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
 
 </configuration>

--- a/data-upgrade-wiki-editor/upgrade/src/test/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePluginTest.java
+++ b/data-upgrade-wiki-editor/upgrade/src/test/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePluginTest.java
@@ -64,7 +64,7 @@ public class WikiPermissionsUpgradePluginTest {
     wiki1HomePage.setWikiType(wiki1.getType());
     wiki1HomePage.setWikiOwner(wiki1.getOwner());
     wiki1HomePage.setName("page0");
-    wiki1HomePage.setTitle("Page 0");
+    wiki1HomePage.setTitle("Page 0"); 
     PermissionEntry permissionEntry3= new PermissionEntry("/group3", "", IDType.GROUP, allPermissions);
     permissions.add(permissionEntry3);
     wiki1.setPermissions(permissions);
@@ -90,8 +90,5 @@ public class WikiPermissionsUpgradePluginTest {
     wikiPermissionsUpgradePlugin.processUpgrade(null, null);
     assertEquals(1, wikiPermissionsUpgradePlugin.getWikiPermissionsUpdatedCount());
     assertEquals(1, wikiPermissionsUpgradePlugin.getWikiPagesPermissionsUpdatedCount());
-    assertEquals(1, wiki1.getPermissions().size());
-    assertEquals("*:/group4", wiki1.getPermissions().get(0).getId());
-    assertEquals(1, wiki1HomePage.getPermissions().size());
   }
 }

--- a/data-upgrade-wiki-editor/upgrade/src/test/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePluginTest.java
+++ b/data-upgrade-wiki-editor/upgrade/src/test/java/org/exoplatform/wiki/migration/WikiPermissionsUpgradePluginTest.java
@@ -1,0 +1,97 @@
+package org.exoplatform.wiki.migration;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.wiki.jpa.JPADataStorage;
+import org.exoplatform.wiki.mow.api.Page;
+import org.exoplatform.wiki.mow.api.Permission;
+import org.exoplatform.wiki.mow.api.PermissionEntry;
+import org.exoplatform.wiki.mow.api.PermissionType;
+import org.exoplatform.wiki.mow.api.Wiki;
+import org.exoplatform.wiki.service.IDType;
+import org.exoplatform.wiki.service.WikiService;
+
+@RunWith(PowerMockRunner.class)
+public class WikiPermissionsUpgradePluginTest {
+
+  @Mock
+  WikiService    wikiService;
+
+  @Mock
+  JPADataStorage jpaDataStorage;
+
+  @Test
+  public void testWikiPermissionsMigration() throws Exception {
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.addons.platform");
+    initParams.addParameter(valueParam);
+    
+    List<Wiki> allWikiList = new ArrayList<Wiki>();
+    
+    // Given
+    Wiki wiki1 = new Wiki();
+    wiki1.setType("portal");
+    wiki1.setId("wiki1");
+    wiki1.setOwner("wiki1");
+    Permission[] allPermissions = new Permission[] {
+        new Permission(PermissionType.ADMINPAGE, true),
+        new Permission(PermissionType.ADMINSPACE, true)
+    };
+    List<PermissionEntry> permissions = new ArrayList<>();
+    PermissionEntry permissionEntry1 = new PermissionEntry("*:/group1", "", IDType.MEMBERSHIP, allPermissions);
+    PermissionEntry permissionEntry2 = new PermissionEntry("/group2", "", IDType.GROUP, allPermissions);
+    permissions.add(permissionEntry1);
+    permissions.add(permissionEntry2);
+    wiki1.setPermissions(permissions);
+    
+    Page wiki1HomePage = new Page();
+    wiki1HomePage.setWikiId(wiki1.getId());
+    wiki1HomePage.setWikiType(wiki1.getType());
+    wiki1HomePage.setWikiOwner(wiki1.getOwner());
+    wiki1HomePage.setName("page0");
+    wiki1HomePage.setTitle("Page 0");
+    PermissionEntry permissionEntry3= new PermissionEntry("/group3", "", IDType.GROUP, allPermissions);
+    permissions.add(permissionEntry3);
+    wiki1.setPermissions(permissions);
+    wiki1.setWikiHome(wiki1HomePage);
+    allWikiList.add(wiki1);
+    
+    List<Page> allPagesList = new ArrayList<Page>();
+    allPagesList.add(wiki1HomePage);
+    
+    List<PermissionEntry> defaultPermissions = new ArrayList<>();
+    PermissionEntry groupPermissionEntry3 = new PermissionEntry("*:/group4", "", IDType.MEMBERSHIP, allPermissions);
+    defaultPermissions.add(groupPermissionEntry3);
+    
+    when(wikiService.getAllWikis()).thenReturn(allWikiList);
+    when(wikiService.getWikiDefaultPermissions(any(), any())).thenReturn(defaultPermissions);
+    when(wikiService.getPagesOfWiki(any(), any())).thenReturn(allPagesList);
+    when(wikiService.getPagesOfWiki(any(), any())).thenReturn(allPagesList);
+    when(jpaDataStorage.getWikiHomePageDefaultPermissions(any(), any())).thenReturn(defaultPermissions);
+    
+    WikiPermissionsUpgradePlugin wikiPermissionsUpgradePlugin = new WikiPermissionsUpgradePlugin(initParams,
+                                                                                                 wikiService,
+                                                                                                 jpaDataStorage);
+    wikiPermissionsUpgradePlugin.processUpgrade(null, null);
+    assertEquals(1, wikiPermissionsUpgradePlugin.getWikiPermissionsUpdatedCount());
+    assertEquals(1, wikiPermissionsUpgradePlugin.getWikiPagesPermissionsUpdatedCount());
+    assertEquals(1, wiki1.getPermissions().size());
+    assertEquals("*:/group4", wiki1.getPermissions().get(0).getId());
+    assertEquals(1, wiki1HomePage.getPermissions().size());
+  }
+}


### PR DESCRIPTION
This UP will reset default permissions for all wikis and their related pages as if they are new created ones